### PR TITLE
add core/assets settings paths to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 /mapdata.json
 /error.txt
 /releasing.txt
+/Updater/out
+/core/assets/error.txt
+/core/assets/mapdata.json
+/core/assets/settings/


### PR DESCRIPTION
They're used with `gradle run` on my machine.